### PR TITLE
feat: Add Working Hours selection to enable sleep during non-working hours

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,19 +6,37 @@ import (
 
 const (
 	gitRepo string = "https://github.com/sonjek/mouse-stay-up"
+
+	workingHours00_00 = "00:00-00:00"
+	workingHours08_18 = "08:00-18:00"
+	workingHours09_19 = "09:00-19:00"
+	workingHours10_19 = "10:00-19:00"
+	workingHours10_20 = "10:00-20:00"
 )
 
+var workingHours = []string{
+	workingHours08_18,
+	workingHours09_19,
+	workingHours10_19,
+	workingHours10_20,
+	workingHours00_00,
+}
+
 type Config struct {
-	Enabled       bool
-	GitRepo       string
-	SleepInterval time.Duration
+	Enabled              bool
+	GitRepo              string
+	SleepInterval        time.Duration
+	WorkingHoursInterval string
+	WorkingHours         []string
 }
 
 func NewConfig() *Config {
 	return &Config{
-		Enabled:       true,
-		GitRepo:       gitRepo,
-		SleepInterval: -1,
+		Enabled:              true,
+		GitRepo:              gitRepo,
+		SleepInterval:        -1,
+		WorkingHoursInterval: workingHours10_19,
+		WorkingHours:         workingHours,
 	}
 }
 
@@ -28,4 +46,8 @@ func (c *Config) SetSleepInterval(interval time.Duration) {
 
 func (c *Config) SetSleepIntervalSec(sec int) {
 	c.SetSleepInterval(time.Duration(sec) * time.Second)
+}
+
+func (c *Config) SetWorkingHoursInterval(interval string) {
+	c.WorkingHoursInterval = interval
 }

--- a/internal/mouse/mouse.go
+++ b/internal/mouse/mouse.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/go-vgo/robotgo"
-
 	"github.com/sonjek/mouse-stay-up/internal/config"
+	"github.com/sonjek/mouse-stay-up/internal/utils"
 )
 
 type Controller struct {
@@ -24,6 +24,13 @@ func (c *Controller) MoveMouse() {
 	for c.config.Enabled {
 		// Sleep before the check
 		c.sleep()
+
+		// Check if the current time is within working hours.
+		// If not, there is no reason to move the cursor.
+		isWorkingHours := utils.IsInWorkingHours(c.config.WorkingHoursInterval)
+		if !isWorkingHours {
+			continue
+		}
 
 		// Get current mouse position
 		curX, curY := robotgo.Location()

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,9 +1,16 @@
 package utils
 
 import (
+	"fmt"
+	"math/rand/v2"
 	"os/exec"
 	"runtime"
+	"strings"
+	"time"
 )
+
+// layout is the time format layout
+const timeLayout = "15:04"
 
 func OpenWebPage(url string) {
 	switch runtime.GOOS {
@@ -14,4 +21,49 @@ func OpenWebPage(url string) {
 	default:
 		panic("unsupported platform")
 	}
+}
+
+func IsInWorkingHours(timeWindow string) bool {
+	parts := strings.Split(timeWindow, "-")
+
+	// If the start and end times are equal, it means the interval spans the entire day
+	if parts[0] == parts[1] {
+		return true
+	}
+
+	startTimeBefore := MakeRandomTime(parts[0])
+	endTimeAfter := MakeRandomTime(parts[1])
+	currentTime := time.Now()
+
+	// Check if the current time is within the dynamic range
+	if currentTime.After(startTimeBefore) && currentTime.Before(endTimeAfter) {
+		return true
+	}
+	return false
+}
+
+func MakeRandomTime(inputTime string) time.Time {
+	// Parse input time like 19:00 to date time
+	parsedTime, err := time.Parse(timeLayout, inputTime)
+	if err != nil {
+		fmt.Println("Error parsing time:", err)
+		return time.Time{}
+	}
+
+	// Generate a random interval between 3 to 14 minutes
+	randomInterval := time.Duration(rand.N(12)+3) * time.Minute
+
+	// Randomly decide whether to add or subtract the interval
+	if rand.N(2) == 0 {
+		parsedTime = parsedTime.Add(randomInterval)
+	} else {
+		parsedTime = parsedTime.Add(-randomInterval)
+	}
+
+	// Get the current date
+	now := time.Now()
+
+	// Combine the current date with the parsed time
+	return time.Date(now.Year(), now.Month(), now.Day(),
+		parsedTime.Hour(), parsedTime.Minute(), parsedTime.Second(), 0, now.Location())
 }


### PR DESCRIPTION
Introduce a `Working Hours` parameter to disable mouse movement and permit the system to enter sleep mode during specified non-working hours.

 These time windows will be slightly dynamic, randomly shifting within a range of `3` to `14` minutes in positive and negative directions to make the behavioral pattern less obvious.

Additionally, the value `00:00-00:00` indicates that the system should never enter sleep mode.

Default value is: `10:00-19:00`

<img width="276" alt="image" src="https://github.com/sonjek/mouse-stay-up/assets/1969460/f98ad9ce-d8cf-4e04-af16-f3f795241d8a">
