### PR TITLE
feat: Remove custom Sleep Interval selection

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,9 +1,5 @@
 package config
 
-import (
-	"time"
-)
-
 const (
 	gitRepo string = "https://github.com/sonjek/mouse-stay-up"
 
@@ -25,7 +21,6 @@ var workingHours = []string{
 type Config struct {
 	Enabled              bool
 	GitRepo              string
-	SleepInterval        time.Duration
 	WorkingHoursInterval string
 	WorkingHours         []string
 }
@@ -34,18 +29,9 @@ func NewConfig() *Config {
 	return &Config{
 		Enabled:              true,
 		GitRepo:              gitRepo,
-		SleepInterval:        -1,
 		WorkingHoursInterval: workingHours10_19,
 		WorkingHours:         workingHours,
 	}
-}
-
-func (c *Config) SetSleepInterval(interval time.Duration) {
-	c.SleepInterval = interval
-}
-
-func (c *Config) SetSleepIntervalSec(sec int) {
-	c.SetSleepInterval(time.Duration(sec) * time.Second)
 }
 
 func (c *Config) SetWorkingHoursInterval(interval string) {

--- a/internal/mouse/mouse.go
+++ b/internal/mouse/mouse.go
@@ -52,14 +52,7 @@ func (c *Controller) MoveMouse() {
 }
 
 func (c *Controller) sleep() {
-	var duration time.Duration
-
-	if c.config.SleepInterval > 0 {
-		duration = c.config.SleepInterval
-	} else {
-		// Get random duration between 10-60 sec
-		duration = time.Duration(rand.N(51)+10) * time.Second
-	}
-
+	// Get random duration between 10-60 sec
+	duration := time.Duration(rand.N(51)+10) * time.Second
 	time.Sleep(duration)
 }


### PR DESCRIPTION
A dynamic checking interval of 10-60 seconds is sufficient for monitoring system activity and preventing sleep.
The option to choose other static intervals is unnecessary and may be removed.

<img width="274" alt="image" src="https://github.com/sonjek/mouse-stay-up/assets/1969460/c26278f2-4d68-420b-847f-5cdb2fcd9275">
