### PR TITLE
ci: Add skip-cache: true for golangci/golangci-lint-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
         uses: golangci/golangci-lint-action@v4
         with:
           version: latest
+          skip-cache: true
           args: --verbose
   build:
     runs-on: macos-latest


### PR DESCRIPTION
Fix for https://github.com/sonjek/mouse-stay-up/actions/runs/8582757807