### PR TITLE
feat: Dynamic shift of working hours don't exceed end time or precede start time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,3 +48,8 @@ uninstall: clean
 .PHONY: start
 start: get-deps
 	go run ./cmd/app
+
+## test: Run unit tests
+.PHONY: test
+test:
+	@go test ./...

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"testing"
+	"time"
+)
+
+// Test value is within the range of 3 to 14 minutes
+func TestGenerateTimeInterval(t *testing.T) {
+	for range 100 {
+		result := generateTimeInterval()
+		if result < 3*time.Minute || result >= 15*time.Minute {
+			t.Errorf("generateTimeInterval() = %v, want %v to %v", result, 3*time.Minute, 15*time.Minute)
+		}
+	}
+}
+
+// Test checks if the function merges two times correctly
+func TestCombineNowAndShiftTime(t *testing.T) {
+	now := time.Date(2024, 4, 7, 10, 0, 45, 0, time.UTC)
+	shiftTime := time.Date(2000, 1, 1, 15, 30, 0, 0, time.UTC)
+	expected := time.Date(2024, 4, 7, 15, 30, 45, 0, time.UTC)
+	result := combineNowAndShiftTime(now, shiftTime)
+
+	if !result.Equal(expected) {
+		t.Errorf("combineNowAndShiftTime(%v, %v) = %v, want %v", now, shiftTime, result, expected)
+	}
+}


### PR DESCRIPTION
When an interval is selected, the dynamic shift should ensure that the adjustment doesn't extend beyond the start or precede the end of working hours.

For instance, a typical work schedule of `09:00-19:00` could be adjusted to `09:14-18:46`.

This shift introduces flexibility in start and end times, which helps maintain the program's activity without raising suspicion. However, it's crucial that these adjustments don't delay the commencement of work or cause the workday to conclude prematurely.

According to the new logic, the beginning of the workday will be shifted forward by `3-14 minutes`, and the end of the workday will be extended by `3-14 minutes`.

`09:00-19:00` will be adjusted to start sometime between `08:46 and 09:00` and end of working hours between `19:00 and 19:14`.

