### PR TITLE
chore: Switch from math/rand/v2 to crypto/rand

### DIFF
--- a/internal/mouse/mouse.go
+++ b/internal/mouse/mouse.go
@@ -1,7 +1,6 @@
 package mouse
 
 import (
-	"math/rand/v2"
 	"time"
 
 	"github.com/go-vgo/robotgo"
@@ -39,8 +38,8 @@ func (c *Controller) MoveMouse() {
 		// If position has not changed, then move the cursor
 		if c.LastX == curX && c.LastY == curY {
 			// Random movement distance along the X-axis and Y-axis (between -8 and 8)
-			relX := (rand.N(9) - 4) * 2
-			relY := (rand.N(9) - 4) * 2
+			relX := utils.GetRandomOffset()
+			relY := utils.GetRandomOffset()
 
 			// Move the cursor
 			robotgo.MoveSmoothRelative(relX, relY)
@@ -53,6 +52,6 @@ func (c *Controller) MoveMouse() {
 
 func (c *Controller) sleep() {
 	// Get random duration between 10-60 sec
-	duration := time.Duration(rand.N(51)+10) * time.Second
+	duration := utils.GetRandomSleepDuration()
 	time.Sleep(duration)
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,8 +1,9 @@
 package utils
 
 import (
+	"crypto/rand"
 	"errors"
-	"math/rand/v2"
+	"math/big"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -76,11 +77,35 @@ func subtractRandomTimeInterval(currentTime time.Time, inputTime string) time.Ti
 
 // Generate a random interval between 3 to 14 minutes
 func generateTimeInterval() time.Duration {
-	return time.Duration(rand.N(12)+3) * time.Minute
+	n, err := rand.Int(rand.Reader, big.NewInt(12))
+	if err != nil {
+		panic(err)
+	}
+
+	return time.Duration(n.Int64()+3) * time.Minute
 }
 
 // Combine the current date with the parsed time (hour-minute)
 func combineNowAndShiftTime(now, shiftTime time.Time) time.Time {
 	return time.Date(now.Year(), now.Month(), now.Day(),
 		shiftTime.Hour(), shiftTime.Minute(), now.Second(), 0, now.Location())
+}
+
+// Random duration between 10-60 sec
+func GetRandomSleepDuration() time.Duration {
+	max := big.NewInt(51) // Upper bound is 51 to get values from 0 to 50
+	n, err := rand.Int(rand.Reader, max)
+	if err != nil {
+		panic(err)
+	}
+	return time.Duration(n.Int64()+10) * time.Second
+}
+
+// Random movement distance between -8 and 8
+func GetRandomOffset() int {
+	n, err := rand.Int(rand.Reader, big.NewInt(9))
+	if err != nil {
+		panic(err)
+	}
+	return int((n.Int64() - 4) * 2)
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -26,3 +26,23 @@ func TestCombineNowAndShiftTime(t *testing.T) {
 		t.Errorf("combineNowAndShiftTime(%v, %v) = %v, want %v", now, shiftTime, result, expected)
 	}
 }
+
+// Test value is within the range 10-60 sec
+func TestGetRandomSleepDuration(t *testing.T) {
+	for range 100 {
+		result := GetRandomSleepDuration()
+		if result < 10*time.Second || result > 60*time.Second {
+			t.Errorf("GetRandomSleepDuration() = %v, want %v to %v", result, 10*time.Second, 60*time.Second)
+		}
+	}
+}
+
+// Test value is within the range -8 and 8
+func TestGetRandomOffset(t *testing.T) {
+	for range 100 {
+		result := GetRandomOffset()
+		if result < -8 || result > 8 {
+			t.Errorf("GetRandomSleepDuration() = %v, want %v to %v", result, -8, 8)
+		}
+	}
+}


### PR DESCRIPTION
Fix lint errors:
Error: internal/utils/utils.go:79:23: G404: Use of weak random number generator (math/rand or math/rand/v2 instead of crypto/rand) (gosec)
Error: internal/mouse/mouse.go:42:13: G404: Use of weak random number generator (math/rand or math/rand/v2 instead of crypto/rand) (gosec)
Error: internal/mouse/mouse.go:43:13: G404: Use of weak random number generator (math/rand or math/rand/v2 instead of crypto/rand) (gosec)